### PR TITLE
Fix block icons and add dialogue icon

### DIFF
--- a/icons/bp/dialogue.svg
+++ b/icons/bp/dialogue.svg
@@ -1,0 +1,1 @@
+<svg clip-rule="evenodd" fill-rule="evenodd" stroke-linejoin="round" stroke-miterlimit="2" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="m12 1c-2 2-4 4-7 4h-4v5h4c3 0 5 2 7 4zm1 4v5c2.59-.016 2.59-4.985 0-5zm-11 6v4h2l1-4z" fill="#fc7f7f" fill-rule="nonzero"/></svg>

--- a/theme.json
+++ b/theme.json
@@ -79,9 +79,6 @@
 		"block.rp": {
 			"iconPath": "./icons/rp/block.svg",
 		},
-		"block": {
-			"iconPath": "./icons/bp/block.svg",
-		},
 
 // Item
 
@@ -212,16 +209,8 @@
 		"entity.json": "entity",
 		"e.json": "entity",
 // Block
-		"block.bp.json": "block.bp",
-		"b.bp.json": "block.bp",
-		"bpb.json": "block.bp",
-
-		"block.rp.json": "block.rp",
-		"b.rp.json": "block.rp",
-		"rpb.json": "block.rp",
-
-		"block.json": "block",
-		"b.json": "block",
+		"block.json": "block.bp",
+		"b.json": "block.bp",
 
 // Block
 		"item.bp.json": "item.bp",
@@ -290,7 +279,8 @@
 		"manifest.json": "manifest",
 		"languages.json": "language_file",
 		"language_names.json": "language_file",
-		"tick.json": "tick"
+		"tick.json": "tick",
+		"blocks.json": "block.rp",
 	},
 	"file": "file"
 }

--- a/theme.json
+++ b/theme.json
@@ -91,7 +91,10 @@
 		"item":{
 			"iconPath": "./icons/bp/item.svg",
 		},
-
+// Dialogue
+		"dialogue.bp" :{
+			"iconPath": "./icons/bp/dialogue.svg",
+		},
 // General
 		"biome": {
 			"iconPath": "./icons/bp/biome.svg",
@@ -212,7 +215,7 @@
 		"block.json": "block.bp",
 		"b.json": "block.bp",
 
-// Block
+// Item
 		"item.bp.json": "item.bp",
 		"i.bp.json": "item.bp",
 		"bpi.json": "item.bp",
@@ -223,7 +226,10 @@
 
 		"item.json": "item",
 		"i.json": "item",
-
+// Dialogue
+		"dialogue.json": "dialogue.bp",
+		"dialog.json": "dialogue.bp",
+		"d.json": "dialogue.bp",
 
 // Misc
 		"biome.json": "biome",


### PR DESCRIPTION
- Fixed the icons for blocks (a resource pack block icon were definied but such thing doesn't exist in bedrock packs). Changes:
    - removed 'block' icon definition
    - removed use of file extensions that used 'block.rp' icon
    - removed use of file extensions that used 'block.bp' icon
    - the file extension that used 'block' now use 'block.bp' icon
    - added new file to the list of recognized files: 'blocks.json'
- Added dialogue icon.